### PR TITLE
filled in the README based on the rust-cargo-runner README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,13 @@
 # rust
-Docker image for Rust
+
+This is a Docker image with Rust 1.18 installed.
+
+## Usage
+
+In order to use this image for your playground on [tech.io](https://tech.io), edit the `techio.yml` file and add the following lines:
+
+```yaml
+    runner: techio/rust:latest
+```
+
+See the [Rust template repository](https://github.com/TechDotIO/rust-template) for more details.


### PR DESCRIPTION
I'm not sure about the project structure, which does not match what we do in the template. Should we change it here?

Also, this is a minor thing, but normally you would put this kind of test (like `test_to_upper`) in the same file as the `to_upper` function.